### PR TITLE
Performance improvements

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.2.1-bin.zip

--- a/src/main/java/teamroots/embers/ConfigManager.java
+++ b/src/main/java/teamroots/embers/ConfigManager.java
@@ -29,7 +29,7 @@ public class ConfigManager {
 					ancientGolemSpawnWeight;
 	public static HashSet<Integer> orespawnGraylist = new HashSet<>();
 	public static boolean orespawnIsWhiteList;
-	
+
 	//STRUCTURES
 	public static int smallRuinChance;
 	public static HashSet<Integer> smallRuinGraylist = new HashSet<>();
@@ -59,6 +59,10 @@ public class ConfigManager {
 	public static boolean pvpEverybodyIsEnemy;
 	public static boolean codexCategoryIsProgress;
 	public static boolean codexEntryIsProgress;
+
+	//CLIENT
+	public static boolean enableParticleCollisions;
+	public static boolean enableParticles;
 
 	//PARAMETERS
 	public static int melterOreAmount;
@@ -101,7 +105,7 @@ public class ConfigManager {
 			load();
 		}
 	}
-	
+
 	public static void load()
 	{
 		config.addCustomCategoryComment("ores", "Settings related to ore generation.");
@@ -110,34 +114,34 @@ public class ConfigManager {
 			orespawnGraylist.add(Integer.valueOf(s));
 		}
 		orespawnIsWhiteList = config.getBoolean("oreBlacklistIsWhitelist","ores",false,"Whether the orespawn blacklist is a whitelist.");
-		
+
 		copperVeinSize = config.getInt("copperVeinSize", "ores", 12, 0, 255, "Maximum size of a copper ore vein (in blocks)");
 		copperMinY = config.getInt("copperMinY", "ores", 0, 0, 254, "Minimum height over which copper ore will spawn.");
 		copperMaxY = config.getInt("copperMaxY", "ores", 64, 1, 255, "Maximum height under which copper ore will spawn.");
 		copperVeinsPerChunk = config.getInt("copperVeinsPerChunk", "ores", 6, 0, 255, "Number of attempts to spawn copper ore the world generator will make for each chunk.");
-		
+
 		leadVeinSize = config.getInt("leadVeinSize", "ores", 8, 0, 255, "Maximum size of a lead ore vein (in blocks)");
 		leadMinY = config.getInt("leadMinY", "ores", 0, 0, 254, "Minimum height over which lead ore will spawn.");
 		leadMaxY = config.getInt("leadMaxY", "ores", 28, 1, 255, "Maximum height under which lead ore will spawn.");
 		leadVeinsPerChunk = config.getInt("leadVeinsPerChunk", "ores", 4, 0, 255, "Number of attempts to spawn lead ore the world generator will make for each chunk.");
-		
+
 		silverVeinSize = config.getInt("silverVeinSize", "ores", 6, 0, 255, "Maximum size of a silver ore vein (in blocks)");
 		silverMinY = config.getInt("silverMinY", "ores", 0, 0, 254, "Minimum height over which silver ore will spawn.");
 		silverMaxY = config.getInt("silverMaxY", "ores", 28, 1, 255, "Maximum height under which silver ore will spawn.");
 		silverVeinsPerChunk = config.getInt("silverVeinsPerChunk", "ores", 4, 0, 255, "Number of attempts to spawn silver ore the world generator will make for each chunk.");
-		
+
 		quartzVeinSize = config.getInt("quartzVeinSize", "ores", 8, 0, 255, "Maximum size of a quartz ore vein (in blocks)");
 		quartzMinY = config.getInt("quartzMinY", "ores", 0, 0, 254, "Minimum height over which quartz ore will spawn.");
 		quartzMaxY = config.getInt("quartzMaxY", "ores", 18, 1, 255, "Maximum height under which quartz ore will spawn.");
 		quartzVeinsPerChunk = config.getInt("quartzVeinsPerChunk", "ores", 4, 0, 255, "Number of attempts to spawn quartz ore the world generator will make for each chunk.");
-		
+
 		config.addCustomCategoryComment("mobs", "Settings related to ore generation.");
-		
+
 		ancientGolemSpawnWeight = config.getInt("ancientGolemSpawnWeight", "mobs", 25, 0, 32767, "Spawning weight of the Ancient Golem mob. Higher values make golems spawn more frequently.");
 		ancientGolemKnockbackResistance = config.getFloat("ancientGolemKnockbackResistance", "mobs", 1.0f, 0.0f, 1.0f, "How much knockback resistance Ancient Golems have.");
 
 		config.addCustomCategoryComment("structures", "Settings related to structure generation.");
-		
+
 		smallRuinChance = config.getInt("smallRuinChance", "structures", 5, 0, 32767, "Spawning frequency of the small ruin structure. A value of 0 will prevent spawning altogether.");
 
 		for (String s : config.getStringList("smallRuinBlacklist", "structures", new String[]{"0"}, "A list of all dimension IDs in which Embers small ruin generation is prohibited.")){
@@ -152,17 +156,17 @@ public class ConfigManager {
 		enableAluminum = config.getBoolean("enableAluminum", "compat", true, "If true, Embers will register items, blocks, and recipes providing support for other mods' aluminum.");
 		enableBronze = config.getBoolean("enableBronze", "compat", true, "If true, Embers will register items, blocks, and recipes providing support for other mods' bronze.");
 		enableElectrum = config.getBoolean("enableElectrum", "compat", true, "If true, Embers will register items, blocks, and recipes providing support for other mods' electrum.");
-		
+
 		aluminumVeinSize = config.getInt("aluminumVeinSize", "compat", 6, 0, 255, "Maximum size of a aluminum ore vein (in blocks)");
 		aluminumMinY = config.getInt("aluminumMinY", "compat", 0, 0, 254, "Minimum height over which aluminum ore will spawn.");
 		aluminumMaxY = config.getInt("aluminumMaxY", "compat", 58, 1, 255, "Maximum height under which aluminum ore will spawn.");
 		aluminumVeinsPerChunk = config.getInt("aluminumVeinsPerChunk", "compat", 4, 0, 255, "Number of attempts to spawn aluminum ore the world generator will make for each chunk.");
-		
+
 		nickelVeinSize = config.getInt("nickelVeinSize", "compat", 6, 0, 255, "Maximum size of a nickel ore vein (in blocks)");
 		nickelMinY = config.getInt("nickelMinY", "compat", 0, 0, 254, "Minimum height over which nickel ore will spawn.");
 		nickelMaxY = config.getInt("nickelMaxY", "compat", 24, 1, 255, "Maximum height under which nickel ore will spawn.");
 		nickelVeinsPerChunk = config.getInt("nickelVeinsPerChunk", "compat", 4, 0, 255, "Number of attempts to spawn nickel ore the world generator will make for each chunk.");
-		
+
 		tinVeinSize = config.getInt("tinVeinSize", "compat", 6, 0, 255, "Maximum size of a tin ore vein (in blocks)");
 		tinMinY = config.getInt("tinMinY", "compat", 0, 0, 254, "Minimum height over which tin ore will spawn.");
 		tinMaxY = config.getInt("tinMaxY", "compat", 48, 1, 255, "Maximum height under which tin ore will spawn.");
@@ -174,6 +178,9 @@ public class ConfigManager {
 		pvpEverybodyIsEnemy = config.getBoolean("everybodyIsAnEnemy", "misc", false, "If true, Embers homing projectiles will go for neutral players.");
 		codexCategoryIsProgress = config.getBoolean("codexCategoryIsProgress", "misc", true, "Codex category is shut. Progression is open.");
 		codexEntryIsProgress = config.getBoolean("codexEntryIsProgress", "misc", true, "Codex entry is shut and hide. Progression is open and show.");
+
+		enableParticleCollisions = config.getBoolean("enableParticleCollisions", "client", true, "Whether or not particles should collide with blocks. Disabling this might significantly improve performance.");
+		enableParticles = config.getBoolean("enableParticles", "client", true, "Whether or not particles are enabled. Disabling this will change the gameplay experience but significantly improve performance.");
 
 		DefaultEmberCapability.allAcceptVolatile = loadBoolean("parameters.allAcceptVolatile", false, "Whether ember conduits can attach to any ember consumer/producer");
 

--- a/src/main/java/teamroots/embers/particle/ParticleAsh.java
+++ b/src/main/java/teamroots/embers/particle/ParticleAsh.java
@@ -1,11 +1,10 @@
 package teamroots.embers.particle;
 
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.particle.Particle;
 import net.minecraft.client.renderer.BufferBuilder;
-import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.entity.Entity;
 import net.minecraft.world.World;
+import teamroots.embers.ConfigManager;
 import teamroots.embers.proxy.ClientProxy;
 
 public class ParticleAsh extends Particle implements IEmberParticle {
@@ -17,6 +16,8 @@ public class ParticleAsh extends Particle implements IEmberParticle {
         height = y2 - y1;
         depth = z2 - z1;
         this.particleMaxAge = (int)(lifetime *0.5f);
+
+        this.canCollide = ConfigManager.enableParticleCollisions;
     }
 
     @Override

--- a/src/main/java/teamroots/embers/particle/ParticleFireBlast.java
+++ b/src/main/java/teamroots/embers/particle/ParticleFireBlast.java
@@ -4,6 +4,7 @@ import net.minecraft.client.particle.Particle;
 import net.minecraft.client.renderer.BufferBuilder;
 import net.minecraft.entity.Entity;
 import net.minecraft.world.World;
+import teamroots.embers.ConfigManager;
 
 import java.awt.*;
 
@@ -16,6 +17,7 @@ public class ParticleFireBlast extends Particle implements IEmberParticle {
         this.particleScale = scale;
         this.particleMaxAge = lifetime;
 
+        this.canCollide = ConfigManager.enableParticleCollisions;
     }
 
     @Override

--- a/src/main/java/teamroots/embers/particle/ParticleGlow.java
+++ b/src/main/java/teamroots/embers/particle/ParticleGlow.java
@@ -2,11 +2,10 @@ package teamroots.embers.particle;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.particle.Particle;
-import net.minecraft.client.renderer.BufferBuilder;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
-import net.minecraft.entity.Entity;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
+import teamroots.embers.ConfigManager;
 import teamroots.embers.util.Misc;
 
 public class ParticleGlow extends Particle implements IEmberParticle{
@@ -41,23 +40,25 @@ public class ParticleGlow extends Particle implements IEmberParticle{
 		this.particleAngle = 2.0f*(float)Math.PI;
 	    TextureAtlasSprite sprite = Minecraft.getMinecraft().getTextureMapBlocks().getAtlasSprite(texture.toString());
 	    this.setParticleTexture(sprite);
+
+		this.canCollide = ConfigManager.enableParticleCollisions;
 	}
 
 	@Override
 	public int getBrightnessForRender(float pTicks){
 		return 255;
 	}
-	
+
 	@Override
 	public boolean shouldDisableDepth(){
 		return true;
 	}
-	
+
 	@Override
 	public int getFXLayer(){
 		return 1;
 	}
-	
+
 	@Override
 	public void onUpdate(){
 		super.onUpdate();

--- a/src/main/java/teamroots/embers/particle/ParticleLineGlow.java
+++ b/src/main/java/teamroots/embers/particle/ParticleLineGlow.java
@@ -5,6 +5,7 @@ import net.minecraft.client.particle.Particle;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
+import teamroots.embers.ConfigManager;
 import teamroots.embers.util.Misc;
 
 public class ParticleLineGlow extends Particle implements IEmberParticle{
@@ -49,6 +50,8 @@ public class ParticleLineGlow extends Particle implements IEmberParticle{
 		this.particleAngle = 2.0f*(float)Math.PI;
 	    TextureAtlasSprite sprite = Minecraft.getMinecraft().getTextureMapBlocks().getAtlasSprite(texture.toString());
 	    this.setParticleTexture(sprite);
+
+		this.canCollide = ConfigManager.enableParticleCollisions;
 	}
 	/*
 	@Override
@@ -57,22 +60,22 @@ public class ParticleLineGlow extends Particle implements IEmberParticle{
 		GlStateManager.blendFunc(SourceFactor.SRC_ALPHA, DestFactor.ONE);
 		super.renderParticle(buffer, entity, partialTicks, rotX, rotZ, rotYZ, rotXY, rotXZ);
 	}*/
-	
+
 	@Override
 	public int getBrightnessForRender(float pTicks){
 		return 255;
 	}
-	
+
 	@Override
 	public boolean shouldDisableDepth(){
 		return true;
 	}
-	
+
 	@Override
 	public int getFXLayer(){
 		return 1;
 	}
-	
+
 	@Override
 	public void onUpdate(){
 		super.onUpdate();

--- a/src/main/java/teamroots/embers/particle/ParticleRenderer.java
+++ b/src/main/java/teamroots/embers/particle/ParticleRenderer.java
@@ -1,6 +1,5 @@
 package teamroots.embers.particle;
 
-import com.google.common.collect.Queues;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.particle.Particle;
 import net.minecraft.client.renderer.ActiveRenderInfo;
@@ -11,15 +10,19 @@ import net.minecraft.client.renderer.texture.TextureMap;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraft.entity.player.EntityPlayer;
 import org.lwjgl.opengl.GL11;
+import teamroots.embers.ConfigManager;
 
-import java.util.*;
+import java.util.ArrayDeque;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Queue;
 
 public class ParticleRenderer {
-    ArrayDeque<Particle> normalParticles = new ArrayDeque<>();
-    ArrayDeque<Particle> additiveParticles = new ArrayDeque<>();
-    ArrayDeque<Particle> throughParticles = new ArrayDeque<>();
-    ArrayDeque<Particle> additiveThroughParticles = new ArrayDeque<>();
-    Queue<Particle> queue = Queues.<Particle>newArrayDeque();
+    private final ArrayDeque<Particle> normalParticles = new ArrayDeque<>();
+    private final ArrayDeque<Particle> additiveParticles = new ArrayDeque<>();
+    private final ArrayDeque<Particle> throughParticles = new ArrayDeque<>();
+    private final ArrayDeque<Particle> additiveThroughParticles = new ArrayDeque<>();
+    private final Queue<Particle> queue = new ArrayDeque<>();
 
     public void updateParticles() {
         updateParticles(normalParticles);
@@ -42,11 +45,10 @@ public class ParticleRenderer {
         Iterator<Particle> iterator = particles.iterator();
         while (iterator.hasNext()) {
             Particle particle = iterator.next();
-            if (((IEmberParticle) particle).alive())
+            if (((IEmberParticle) particle).alive() && (ConfigManager.enableParticles || particle instanceof ParticleGlow))
                 particle.onUpdate();
-            else {
+            else
                 iterator.remove();
-            }
         }
     }
 
@@ -113,6 +115,9 @@ public class ParticleRenderer {
     }
 
     public void addParticle(Particle particle) {
+        if (!ConfigManager.enableParticles && !(particle instanceof ParticleGlow))
+            return;
+
         if (particle instanceof IEmberParticle) {
             queue.add(particle);
         }

--- a/src/main/java/teamroots/embers/particle/ParticleSmoke.java
+++ b/src/main/java/teamroots/embers/particle/ParticleSmoke.java
@@ -5,41 +5,45 @@ import net.minecraft.client.particle.Particle;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
+import teamroots.embers.ConfigManager;
 import teamroots.embers.util.Misc;
 
-public class ParticleSmoke extends Particle implements IEmberParticle{
-	public float colorR = 0;
-	public float colorG = 0;
-	public float colorB = 0;
-	public float initScale = 0;
-	public float initAlpha = 0;
-	public ResourceLocation texture = new ResourceLocation("embers:entity/particle_smoke");
-	public ParticleSmoke(World worldIn, double x, double y, double z, double vx, double vy, double vz, float r, float g, float b, float a, float scale, int lifetime) {
-		super(worldIn, x,y,z,0,0,0);
-		this.colorR = r;
-		this.colorG = g;
-		this.colorB = b;
-		if (this.colorR > 1.0){
-			this.colorR = this.colorR/255.0f;
-		}
-		if (this.colorG > 1.0){
-			this.colorG = this.colorG/255.0f;
-		}
-		if (this.colorB > 1.0){
-			this.colorB = this.colorB/255.0f;
-		}
-		this.setRBGColorF(colorR, colorG, colorB);
-		this.particleMaxAge = lifetime;
-		this.particleScale = scale;
-		this.initScale = scale;
-		this.motionX = vx;
-		this.motionY = vy;
-		this.motionZ = vz;
-		this.particleAngle = 2.0f*(float)Math.PI;
-		this.particleAlpha = initAlpha = a;
-	    TextureAtlasSprite sprite = Minecraft.getMinecraft().getTextureMapBlocks().getAtlasSprite(texture.toString());
-	    this.setParticleTexture(sprite);
-	}
+public class ParticleSmoke extends Particle implements IEmberParticle {
+    public float colorR = 0;
+    public float colorG = 0;
+    public float colorB = 0;
+    public float initScale = 0;
+    public float initAlpha = 0;
+    public ResourceLocation texture = new ResourceLocation("embers:entity/particle_smoke");
+
+    public ParticleSmoke(World worldIn, double x, double y, double z, double vx, double vy, double vz, float r, float g, float b, float a, float scale, int lifetime) {
+        super(worldIn, x, y, z, 0, 0, 0);
+        this.colorR = r;
+        this.colorG = g;
+        this.colorB = b;
+        if (this.colorR > 1.0) {
+            this.colorR = this.colorR / 255.0f;
+        }
+        if (this.colorG > 1.0) {
+            this.colorG = this.colorG / 255.0f;
+        }
+        if (this.colorB > 1.0) {
+            this.colorB = this.colorB / 255.0f;
+        }
+        this.setRBGColorF(colorR, colorG, colorB);
+        this.particleMaxAge = lifetime;
+        this.particleScale = scale;
+        this.initScale = scale;
+        this.motionX = vx;
+        this.motionY = vy;
+        this.motionZ = vz;
+        this.particleAngle = 2.0f * (float) Math.PI;
+        this.particleAlpha = initAlpha = a;
+        TextureAtlasSprite sprite = Minecraft.getMinecraft().getTextureMapBlocks().getAtlasSprite(texture.toString());
+        this.setParticleTexture(sprite);
+
+        this.canCollide = ConfigManager.enableParticleCollisions;
+    }
 	/*
 	@Override
 	public void renderParticle(BufferBuilder buffer, Entity entity, float partialTicks, float rotX, float rotZ, float rotYZ, float rotXY, float rotXZ){
@@ -47,44 +51,44 @@ public class ParticleSmoke extends Particle implements IEmberParticle{
 		GlStateManager.blendFunc(SourceFactor.SRC_ALPHA, DestFactor.ONE);
 		super.renderParticle(buffer, entity, partialTicks, rotX, rotZ, rotYZ, rotXY, rotXZ);
 	}*/
-	
-	@Override
-	public boolean shouldDisableDepth(){
-		return true;
-	}
-	
-	@Override
-	public int getFXLayer(){
-		return 1;
-	}
-	
-	@Override
-	public void onUpdate(){
-		super.onUpdate();
-		if (Misc.random.nextInt(6) == 0){
-			this.particleAge ++;
-		}
-		float lifeCoeff = (float)this.particleAge/(float)this.particleMaxAge;
-		this.particleScale = initScale-initScale*lifeCoeff;
-		this.particleAlpha = (1.0f-lifeCoeff) * initAlpha;
-		this.motionX *= 0.96D;
-		this.motionY *= 0.96D;
-		this.motionZ *= 0.96D;
-		this.motionY += 0.004D;
-	}
 
-	@Override
-	public boolean alive() {
-		return this.particleAge < this.particleMaxAge;
-	}
+    @Override
+    public boolean shouldDisableDepth() {
+        return true;
+    }
 
-	@Override
-	public boolean isAdditive() {
-		return false;
-	}
+    @Override
+    public int getFXLayer() {
+        return 1;
+    }
 
-	@Override
-	public boolean renderThroughBlocks() {
-		return false;
-	}
+    @Override
+    public void onUpdate() {
+        super.onUpdate();
+        if (Misc.random.nextInt(6) == 0) {
+            this.particleAge++;
+        }
+        float lifeCoeff = (float) this.particleAge / (float) this.particleMaxAge;
+        this.particleScale = initScale - initScale * lifeCoeff;
+        this.particleAlpha = (1.0f - lifeCoeff) * initAlpha;
+        this.motionX *= 0.96D;
+        this.motionY *= 0.96D;
+        this.motionZ *= 0.96D;
+        this.motionY += 0.004D;
+    }
+
+    @Override
+    public boolean alive() {
+        return this.particleAge < this.particleMaxAge;
+    }
+
+    @Override
+    public boolean isAdditive() {
+        return false;
+    }
+
+    @Override
+    public boolean renderThroughBlocks() {
+        return false;
+    }
 }

--- a/src/main/java/teamroots/embers/particle/ParticleSpark.java
+++ b/src/main/java/teamroots/embers/particle/ParticleSpark.java
@@ -5,6 +5,7 @@ import net.minecraft.client.particle.Particle;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
+import teamroots.embers.ConfigManager;
 import teamroots.embers.util.Misc;
 
 public class ParticleSpark extends Particle implements IEmberParticle{
@@ -39,6 +40,8 @@ public class ParticleSpark extends Particle implements IEmberParticle{
 	    TextureAtlasSprite sprite = Minecraft.getMinecraft().getTextureMapBlocks().getAtlasSprite(texture.toString());
 	    this.setParticleTexture(sprite);
 	    this.particleGravity = 0.04f;
+
+		this.canCollide = ConfigManager.enableParticleCollisions;
 	}
 	/*
 	@Override
@@ -47,22 +50,22 @@ public class ParticleSpark extends Particle implements IEmberParticle{
 		GlStateManager.blendFunc(SourceFactor.SRC_ALPHA, DestFactor.ONE);
 		super.renderParticle(buffer, entity, partialTicks, rotX, rotZ, rotYZ, rotXY, rotXZ);
 	}*/
-	
+
 	@Override
 	public int getBrightnessForRender(float pTicks){
 		return 255;
 	}
-	
+
 	@Override
 	public boolean shouldDisableDepth(){
 		return true;
 	}
-	
+
 	@Override
 	public int getFXLayer(){
 		return 1;
 	}
-	
+
 	@Override
 	public void onUpdate(){
 		super.onUpdate();

--- a/src/main/java/teamroots/embers/particle/ParticleStar.java
+++ b/src/main/java/teamroots/embers/particle/ParticleStar.java
@@ -5,6 +5,7 @@ import net.minecraft.client.particle.Particle;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
+import teamroots.embers.ConfigManager;
 import teamroots.embers.util.Misc;
 
 public class ParticleStar extends Particle implements IEmberParticle{
@@ -38,6 +39,8 @@ public class ParticleStar extends Particle implements IEmberParticle{
 		this.particleAngle = 2.0f*(float)Math.PI;
 	    TextureAtlasSprite sprite = Minecraft.getMinecraft().getTextureMapBlocks().getAtlasSprite(texture.toString());
 	    this.setParticleTexture(sprite);
+
+		this.canCollide = ConfigManager.enableParticleCollisions;
 	}
 	/*
 	@Override
@@ -46,22 +49,22 @@ public class ParticleStar extends Particle implements IEmberParticle{
 		GlStateManager.blendFunc(SourceFactor.SRC_ALPHA, DestFactor.ONE);
 		super.renderParticle(buffer, entity, partialTicks, rotX, rotZ, rotYZ, rotXY, rotXZ);
 	}*/
-	
+
 	@Override
 	public int getBrightnessForRender(float pTicks){
 		return 255;
 	}
-	
+
 	@Override
 	public boolean shouldDisableDepth(){
 		return true;
 	}
-	
+
 	@Override
 	public int getFXLayer(){
 		return 1;
 	}
-	
+
 	@Override
 	public void onUpdate(){
 		super.onUpdate();

--- a/src/main/java/teamroots/embers/particle/ParticleTyrfing.java
+++ b/src/main/java/teamroots/embers/particle/ParticleTyrfing.java
@@ -5,6 +5,7 @@ import net.minecraft.client.particle.Particle;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
+import teamroots.embers.ConfigManager;
 import teamroots.embers.EventManager;
 import teamroots.embers.util.Misc;
 
@@ -32,6 +33,8 @@ public class ParticleTyrfing extends Particle implements IEmberParticle{
 		this.particleAngle = 2.0f*(float)Math.PI;
 	    TextureAtlasSprite sprite = Minecraft.getMinecraft().getTextureMapBlocks().getAtlasSprite(texture.toString());
 	    this.setParticleTexture(sprite);
+
+		this.canCollide = ConfigManager.enableParticleCollisions;
 	}
 	/*
 	@Override
@@ -40,22 +43,22 @@ public class ParticleTyrfing extends Particle implements IEmberParticle{
 		GlStateManager.blendFunc(SourceFactor.SRC_ALPHA, DestFactor.ONE);
 		super.renderParticle(buffer, entity, partialTicks, rotX, rotZ, rotYZ, rotXY, rotXZ);
 	}*/
-	
+
 	@Override
 	public int getBrightnessForRender(float pTicks){
 		return 255;
 	}
-	
+
 	@Override
 	public boolean shouldDisableDepth(){
 		return true;
 	}
-	
+
 	@Override
 	public int getFXLayer(){
 		return 1;
 	}
-	
+
 	@Override
 	public void onUpdate(){
 		super.onUpdate();

--- a/src/main/java/teamroots/embers/tileentity/TileEntityEmberBore.java
+++ b/src/main/java/teamroots/embers/tileentity/TileEntityEmberBore.java
@@ -1,6 +1,5 @@
 package teamroots.embers.tileentity;
 
-import mysticalmechanics.api.MysticalMechanicsAPI;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.player.EntityPlayer;
@@ -15,12 +14,10 @@ import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.common.capabilities.Capability;
-import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.ItemStackHandler;
 import teamroots.embers.ConfigManager;
 import teamroots.embers.Embers;
-import teamroots.embers.EventManager;
 import teamroots.embers.SoundManager;
 import teamroots.embers.api.event.DialInformationEvent;
 import teamroots.embers.api.tile.IExtraCapabilityInformation;
@@ -365,13 +362,17 @@ public class TileEntityEmberBore extends TileEntity implements ITileEntityBase, 
 
         @Override
         public ItemStack insertItem(int slot, ItemStack stack, boolean simulate) {
-            int burntime = TileEntityFurnace.getItemBurnTime(stack);
-            if (slot == SLOT_FUEL && burntime != 0) {
-                return super.insertItem(slot, stack, simulate);
-            } else if (burntime != 0) {
-                return super.insertItem(SLOT_FUEL, stack, simulate);
+            ItemStack currentFuel = this.getStackInSlot(SLOT_FUEL);
+            if (currentFuel.isEmpty()) {
+                int burnTime = TileEntityFurnace.getItemBurnTime(stack);
+                if (burnTime != 0)
+                    return super.insertItem(SLOT_FUEL, stack, simulate);
+                else
+                    return stack;
             }
-            return stack;
+
+            //if the item stacks then it has the same burn time, therefore we don't need to check it
+            return super.insertItem(SLOT_FUEL, stack, simulate);
         }
 
         public ItemStack insertItemInternal(int slot, ItemStack stack, boolean simulate) {
@@ -380,9 +381,8 @@ public class TileEntityEmberBore extends TileEntity implements ITileEntityBase, 
 
         @Override
         public ItemStack extractItem(int slot, int amount, boolean simulate) {
-            ItemStack currentFuel = super.extractItem(slot, amount, true);
-            int burntime = TileEntityFurnace.getItemBurnTime(currentFuel);
-            if (slot == SLOT_FUEL && burntime != 0) {
+            //disallow extraction from fuel slot
+            if (slot == SLOT_FUEL) {
                 return ItemStack.EMPTY;
             }
             return super.extractItem(slot, amount, simulate);

--- a/src/main/java/teamroots/embers/tileentity/TileEntityEmberBore.java
+++ b/src/main/java/teamroots/embers/tileentity/TileEntityEmberBore.java
@@ -381,9 +381,11 @@ public class TileEntityEmberBore extends TileEntity implements ITileEntityBase, 
 
         @Override
         public ItemStack extractItem(int slot, int amount, boolean simulate) {
-            //disallow extraction from fuel slot
+            //disallow extraction from fuel slot if it's a stacked item or it doesn't have burn time
             if (slot == SLOT_FUEL) {
-                return ItemStack.EMPTY;
+                ItemStack fuelStack = getStackInSlot(SLOT_FUEL);
+                if (fuelStack.getCount() > 1 || TileEntityFurnace.getItemBurnTime(fuelStack) != 0)
+                    return ItemStack.EMPTY;
             }
             return super.extractItem(slot, amount, simulate);
         }


### PR DESCRIPTION
- Added config options to help with extreme particle lag https://spark.lucko.me/#QgXKjnwEjW (lag caused by 16 cinder plyths with blocks above them -> 1FPS on decent computer). The option enableParticles does not disable the ember packet particles, because it changes the game too much.
- Significantly reduced calls to `TileEntityFurnace#getItemBurnTime`. They are not needed if the stack itself doesn't change. 16 Ember bores which were constantly being inserted into by EnderIO took up 5% of the servers performance because of this.
- Updated the gradle version because it is very outdated