### PR TITLE
Fix model FileNotFound and MissingVariant exceptions

### DIFF
--- a/src/main/java/teamroots/embers/block/BlockInfernoForgeEdge.java
+++ b/src/main/java/teamroots/embers/block/BlockInfernoForgeEdge.java
@@ -78,6 +78,10 @@ public class BlockInfernoForgeEdge extends BlockBase {
 	}
 
 	@Override
+	public void initModel() {
+	}
+
+	@Override
 	public Item getItemBlock() {
 		return null;
 	}

--- a/src/main/java/teamroots/embers/block/BlockMechEdge.java
+++ b/src/main/java/teamroots/embers/block/BlockMechEdge.java
@@ -18,7 +18,7 @@ import teamroots.embers.tileentity.ITileEntityBase;
 import java.util.ArrayList;
 
 public class BlockMechEdge extends BlockBase {
-	public static final PropertyInteger state = PropertyInteger.create("state", 0, 8);
+	public static final PropertyInteger state = PropertyInteger.create("state", 0, 7);
 	
 	public BlockMechEdge(Material material, String name, boolean addToTab) {
 		super(material, name, addToTab);
@@ -141,6 +141,10 @@ public class BlockMechEdge extends BlockBase {
 	@Override
 	public ArrayList<ItemStack> getDrops(IBlockAccess world, BlockPos pos, IBlockState state, int fortune){
 		return new ArrayList<ItemStack>();
+	}
+
+	@Override
+	public void initModel() {
 	}
 
 	@Override

--- a/src/main/java/teamroots/embers/item/ItemInflictorGem.java
+++ b/src/main/java/teamroots/embers/item/ItemInflictorGem.java
@@ -56,8 +56,8 @@ public class ItemInflictorGem extends ItemBase implements IInflictorGem {
 	@Override
 	public void initModel(){
 		ModelBakery.registerItemVariants(this,
-				new ModelResourceLocation(getRegistryName().toString()+"Empty"),
-				new ModelResourceLocation(getRegistryName().toString()+"Full"));
+				new ModelResourceLocation(getRegistryName().toString()+"_empty"),
+				new ModelResourceLocation(getRegistryName().toString()+"_full"));
 		ModelLoader.setCustomModelResourceLocation(this, 0, new ModelResourceLocation(getRegistryName().toString()+"_empty"));
 		ModelLoader.setCustomModelResourceLocation(this, 1, new ModelResourceLocation(getRegistryName().toString()+"_full"));
 	}


### PR DESCRIPTION
```
Exception loading model for variant embers:inflictor_gemempty#normal, normal location exception
Caused by: java.io.FileNotFoundException: embers:models/item/inflictor_gemempty.json

Exception loading model for variant embers:inflictor_gemempty#normal, blockstate location exception
Caused by: net.minecraft.client.renderer.block.model.ModelBlockDefinition$MissingVariantException

Exception loading model for variant embers:inflictor_gemfull#normal, normal location exception
Caused by: java.io.FileNotFoundException: embers:models/item/inflictor_gemfull.json

Exception loading model for variant embers:inflictor_gemfull#normal, blockstate location exception
Caused by: net.minecraft.client.renderer.block.model.ModelBlockDefinition$MissingVariantException

Exception loading model for variant embers:mech_edge#state=8
Caused by: net.minecraft.client.renderer.block.model.ModelBlockDefinition$MissingVariantException

Exception loading model for variant embers:archaic_mech_edge#state=8
Caused by: net.minecraft.client.renderer.block.model.ModelBlockDefinition$MissingVariantException

Exception loading model for variant embers:inferno_forge_edge#inventory, normal location exception
Caused by: java.io.FileNotFoundException: embers:models/item/inferno_forge_edge.json

Exception loading model for variant embers:inferno_forge_edge#inventory, blockstate location exception
Caused by: net.minecraft.client.renderer.block.model.ModelBlockDefinition$MissingVariantException

Exception loading model for variant embers:archaic_mech_edge#inventory, normal location exception
Caused by: java.io.FileNotFoundException: embers:models/item/archaic_mech_edge.json

Exception loading model for variant embers:archaic_mech_edge#inventory, blockstate location exception
Caused by: net.minecraft.client.renderer.block.model.ModelBlockDefinition$MissingVariantException
```