### PR TITLE
Fix Inferno Forge unconditionally replacing a single block directly above it

### DIFF
--- a/src/main/java/teamroots/embers/block/BlockInfernoForge.java
+++ b/src/main/java/teamroots/embers/block/BlockInfernoForge.java
@@ -81,6 +81,7 @@ public class BlockInfernoForge extends BlockTEBase {
 	@Override
 	public boolean canPlaceBlockAt(World world, BlockPos pos){
 		if (isReplaceable(world,pos.east())
+				&& isReplaceable(world,pos.up())
 				&& isReplaceable(world,pos.west())
 				&& isReplaceable(world,pos.north())
 				&& isReplaceable(world,pos.south())


### PR DESCRIPTION
Only happens if there is exactly one block directly above the space that will be occupied by BlockInfernoForge with isTop=false