### PR TITLE
Disable redstone connecting to Embers blocks

### DIFF
--- a/src/main/java/teamroots/embers/block/BlockAutoHammer.java
+++ b/src/main/java/teamroots/embers/block/BlockAutoHammer.java
@@ -21,11 +21,6 @@ public class BlockAutoHammer extends BlockTEBase {
 	}
 	
 	@Override
-	public boolean canConnectRedstone(IBlockState state, IBlockAccess world, BlockPos pos, EnumFacing side){
-		return true;
-	}
-	
-	@Override
 	public BlockStateContainer createBlockState(){
 		return new BlockStateContainer(this, facing);
 	}

--- a/src/main/java/teamroots/embers/block/BlockBeamCannon.java
+++ b/src/main/java/teamroots/embers/block/BlockBeamCannon.java
@@ -20,11 +20,6 @@ public class BlockBeamCannon extends BlockTEBase {
 	}
 	
 	@Override
-	public boolean canConnectRedstone(IBlockState state, IBlockAccess world, BlockPos pos, EnumFacing side){
-		return true;
-	}
-	
-	@Override
 	public BlockStateContainer createBlockState(){
 		return new BlockStateContainer(this, facing);
 	}

--- a/src/main/java/teamroots/embers/block/BlockBreaker.java
+++ b/src/main/java/teamroots/embers/block/BlockBreaker.java
@@ -20,11 +20,6 @@ public class BlockBreaker extends BlockTEBase {
 	}
 	
 	@Override
-	public boolean canConnectRedstone(IBlockState state, IBlockAccess world, BlockPos pos, EnumFacing side){
-		return true;
-	}
-	
-	@Override
 	public BlockStateContainer createBlockState(){
 		return new BlockStateContainer(this, facing);
 	}

--- a/src/main/java/teamroots/embers/block/BlockCharger.java
+++ b/src/main/java/teamroots/embers/block/BlockCharger.java
@@ -21,11 +21,6 @@ public class BlockCharger extends BlockTEBase {
 	}
 	
 	@Override
-	public boolean canConnectRedstone(IBlockState state, IBlockAccess world, BlockPos pos, EnumFacing side){
-		return true;
-	}
-	
-	@Override
 	public BlockStateContainer createBlockState(){
 		return new BlockStateContainer(this, facing);
 	}

--- a/src/main/java/teamroots/embers/block/BlockEmberEmitter.java
+++ b/src/main/java/teamroots/embers/block/BlockEmberEmitter.java
@@ -22,11 +22,6 @@ public class BlockEmberEmitter extends BlockTEBase {
 	}
 	
 	@Override
-	public boolean canConnectRedstone(IBlockState state, IBlockAccess world, BlockPos pos, EnumFacing side){
-		return true;
-	}
-	
-	@Override
 	public BlockStateContainer createBlockState(){
 		return new BlockStateContainer(this, facing);
 	}

--- a/src/main/java/teamroots/embers/block/BlockEmberFunnel.java
+++ b/src/main/java/teamroots/embers/block/BlockEmberFunnel.java
@@ -58,11 +58,6 @@ public class BlockEmberFunnel extends BlockTEBase {
     }
 
     @Override
-    public boolean canConnectRedstone(IBlockState state, IBlockAccess world, BlockPos pos, EnumFacing side) {
-        return true;
-    }
-
-    @Override
     public BlockStateContainer createBlockState() {
         return new BlockStateContainer(this, facing);
     }

--- a/src/main/java/teamroots/embers/block/BlockEmberPulser.java
+++ b/src/main/java/teamroots/embers/block/BlockEmberPulser.java
@@ -22,11 +22,6 @@ public class BlockEmberPulser extends BlockTEBase {
 	}
 	
 	@Override
-	public boolean canConnectRedstone(IBlockState state, IBlockAccess world, BlockPos pos, EnumFacing side){
-		return true;
-	}
-	
-	@Override
 	public BlockStateContainer createBlockState(){
 		return new BlockStateContainer(this, facing);
 	}

--- a/src/main/java/teamroots/embers/block/BlockFluidExtractor.java
+++ b/src/main/java/teamroots/embers/block/BlockFluidExtractor.java
@@ -40,11 +40,6 @@ public class BlockFluidExtractor extends BlockTEBase {
 	}
 	
 	@Override
-	public boolean canConnectRedstone(IBlockState state, IBlockAccess world, BlockPos pos, EnumFacing side){
-		return true;
-	}
-	
-	@Override
 	public boolean canPlaceBlockOnSide(World world, BlockPos pos, EnumFacing side){
 		return true;
 	}

--- a/src/main/java/teamroots/embers/block/BlockFluidTransfer.java
+++ b/src/main/java/teamroots/embers/block/BlockFluidTransfer.java
@@ -22,11 +22,6 @@ public class BlockFluidTransfer extends BlockTEBase {
 	}
 	
 	@Override
-	public boolean canConnectRedstone(IBlockState state, IBlockAccess world, BlockPos pos, EnumFacing side){
-		return true;
-	}
-	
-	@Override
 	public BlockStateContainer createBlockState(){
 		return new BlockStateContainer(this, facing, filter);
 	}

--- a/src/main/java/teamroots/embers/block/BlockItemExtractor.java
+++ b/src/main/java/teamroots/embers/block/BlockItemExtractor.java
@@ -57,11 +57,6 @@ public class BlockItemExtractor extends BlockTEBase {
 	}
 	
 	@Override
-	public boolean canConnectRedstone(IBlockState state, IBlockAccess world, BlockPos pos, EnumFacing side){
-		return true;
-	}
-
-	@Override
 	public RayTraceResult collisionRayTrace(IBlockState state, @Nonnull World world, @Nonnull BlockPos pos, @Nonnull Vec3d start, @Nonnull Vec3d end) {
 		List<AxisAlignedBB> subBoxes = new ArrayList<>();
 

--- a/src/main/java/teamroots/embers/block/BlockItemRequisition.java
+++ b/src/main/java/teamroots/embers/block/BlockItemRequisition.java
@@ -35,11 +35,6 @@ public class BlockItemRequisition extends BlockTEBase implements IDial {
 	}
 	
 	@Override
-	public boolean canConnectRedstone(IBlockState state, IBlockAccess world, BlockPos pos, EnumFacing side){
-		return true;
-	}
-	
-	@Override
 	public BlockStateContainer createBlockState(){
 		return new BlockStateContainer(this, facing);
 	}

--- a/src/main/java/teamroots/embers/block/BlockItemTransfer.java
+++ b/src/main/java/teamroots/embers/block/BlockItemTransfer.java
@@ -22,11 +22,6 @@ public class BlockItemTransfer extends BlockTEBase {
 	}
 	
 	@Override
-	public boolean canConnectRedstone(IBlockState state, IBlockAccess world, BlockPos pos, EnumFacing side){
-		return true;
-	}
-	
-	@Override
 	public BlockStateContainer createBlockState(){
 		return new BlockStateContainer(this, facing, filter);
 	}

--- a/src/main/java/teamroots/embers/block/BlockPump.java
+++ b/src/main/java/teamroots/embers/block/BlockPump.java
@@ -50,11 +50,6 @@ public class BlockPump extends BlockTEBase {
 	}
 	
 	@Override
-	public boolean canConnectRedstone(IBlockState state, IBlockAccess world, BlockPos pos, EnumFacing side){
-		return state.getBlock() instanceof BlockPump && !state.getValue(isTop);
-	}
-	
-	@Override
 	public void onBlockExploded(World world, BlockPos pos, Explosion explosion){
 		if (!world.isRemote){
 			world.spawnEntity(new EntityItem(world,pos.getX()+0.5,pos.getY()+0.5,pos.getZ()+0.5,new ItemStack(this,1,0)));

--- a/src/main/java/teamroots/embers/block/BlockRelay.java
+++ b/src/main/java/teamroots/embers/block/BlockRelay.java
@@ -21,11 +21,6 @@ public class BlockRelay extends BlockTEBase {
 	}
 	
 	@Override
-	public boolean canConnectRedstone(IBlockState state, IBlockAccess world, BlockPos pos, EnumFacing side){
-		return true;
-	}
-	
-	@Override
 	public BlockStateContainer createBlockState(){
 		return new BlockStateContainer(this, facing);
 	}

--- a/src/main/java/teamroots/embers/block/BlockStamper.java
+++ b/src/main/java/teamroots/embers/block/BlockStamper.java
@@ -45,11 +45,6 @@ public class BlockStamper extends BlockTEBase {
 	}
 	
 	@Override
-	public boolean canConnectRedstone(IBlockState state, IBlockAccess world, BlockPos pos, EnumFacing side){
-		return true;
-	}
-
-	@Override
 	public TileEntity createNewTileEntity(World worldIn, int meta) {
 		return new TileEntityStamper();
 	}

--- a/src/main/java/teamroots/embers/block/BlockVacuum.java
+++ b/src/main/java/teamroots/embers/block/BlockVacuum.java
@@ -20,11 +20,6 @@ public class BlockVacuum extends BlockTEBase {
 	}
 	
 	@Override
-	public boolean canConnectRedstone(IBlockState state, IBlockAccess world, BlockPos pos, EnumFacing side){
-		return true;
-	}
-	
-	@Override
 	public BlockStateContainer createBlockState(){
 		return new BlockStateContainer(this, facing);
 	}

--- a/src/main/java/teamroots/embers/tileentity/TileEntityAutoHammer.java
+++ b/src/main/java/teamroots/embers/tileentity/TileEntityAutoHammer.java
@@ -120,7 +120,7 @@ public class TileEntityAutoHammer extends TileEntity implements ITileEntityBase,
 		TileEntity tile = world.getTileEntity(getPos().down().offset(facing));
 		if (tile instanceof IHammerable) {
 			IHammerable hammerable = (IHammerable) tile;
-			boolean redstoneEnabled = getWorld().isBlockIndirectlyGettingPowered(getPos()) != 0;
+			boolean redstoneEnabled = getWorld().isBlockPowered(getPos());
 			if (hammerable.isValid() && redstoneEnabled && capability.getEmber() >= ember_cost) {
 				boolean cancel = UpgradeUtil.doWork(this, upgrades);
 				if (!cancel && progress == -1 && ticksExisted % UpgradeUtil.getWorkTime(this,PROCESS_TIME, upgrades) == 0) {

--- a/src/main/java/teamroots/embers/tileentity/TileEntityBeamCannon.java
+++ b/src/main/java/teamroots/embers/tileentity/TileEntityBeamCannon.java
@@ -136,7 +136,7 @@ public class TileEntityBeamCannon extends TileEntity implements ITileEntityBase,
 		UpgradeUtil.verifyUpgrades(this, upgrades);
 		ticksExisted++;
 		boolean cancel = UpgradeUtil.doWork(this,upgrades);
-		boolean isPowered = getWorld().isBlockIndirectlyGettingPowered(getPos()) != 0;
+		boolean isPowered = getWorld().isBlockPowered(getPos());
 		boolean redstoneEnabled = UpgradeUtil.getOtherParameter(this,"redstone_enabled",true,upgrades);
 		int threshold = UpgradeUtil.getOtherParameter(this,"fire_threshold",FIRE_THRESHOLD,upgrades);
 		if (!cancel && this.capability.getEmber() >= threshold && (!redstoneEnabled || (isPowered && !lastPowered))){

--- a/src/main/java/teamroots/embers/tileentity/TileEntityBreaker.java
+++ b/src/main/java/teamroots/embers/tileentity/TileEntityBreaker.java
@@ -112,33 +112,8 @@ public class TileEntityBreaker extends TileEntity implements ITileEntityBase, IT
 		}
 	}
 
-	public int getRedstonePower()
-	{
-		int maxPower = 0;
-
-		for (EnumFacing facing : EnumFacing.values())
-		{
-			if(facing == getFacing())
-				continue;
-
-			int power = getWorld().getRedstonePower(getPos().offset(facing), facing);
-
-			if (power >= 15)
-			{
-				return 15;
-			}
-
-			if (power > maxPower)
-			{
-				maxPower = power;
-			}
-		}
-
-		return maxPower;
-	}
-
 	public boolean isActive() {
-		return getRedstonePower() == 0;
+		return !getWorld().isBlockPowered(getPos());
 	}
 
 	protected void mineBlock(BlockPos breakPos) {

--- a/src/main/java/teamroots/embers/tileentity/TileEntityEmberPipe.java
+++ b/src/main/java/teamroots/embers/tileentity/TileEntityEmberPipe.java
@@ -46,7 +46,7 @@ public class TileEntityEmberPipe extends TileEntityEmberPipeBase {
 		//if (world.isRemote && clogged && isAnySideUnclogged())
 		//	Misc.spawnClogParticles(world, pos, 1, 0.25f);
 		if (!world.isRemote) {
-			active = getWorld().isBlockIndirectlyGettingPowered(getPos()) != 0;
+			active = getWorld().isBlockPowered(getPos());
 			if(clogged || !active) {
 				currentPush = INIT_PUSH;
 			} else {

--- a/src/main/java/teamroots/embers/tileentity/TileEntityEmitter.java
+++ b/src/main/java/teamroots/embers/tileentity/TileEntityEmitter.java
@@ -167,7 +167,7 @@ public class TileEntityEmitter extends TileEntity implements ITileEntityBase, IT
 				}
 			}
 		}
-		if ((this.ticksExisted+offset) % 20 == 0 && getWorld().isBlockIndirectlyGettingPowered(getPos()) != 0 && target != null && !getWorld().isRemote && this.capability.getEmber() > PULL_RATE){
+		if ((this.ticksExisted+offset) % 20 == 0 && getWorld().isBlockPowered(getPos()) && target != null && !getWorld().isRemote && this.capability.getEmber() > PULL_RATE){
 			TileEntity targetTile = getWorld().getTileEntity(target);
 			if (targetTile instanceof IEmberPacketReceiver){
 				if (!(((IEmberPacketReceiver) targetTile).isFull())){

--- a/src/main/java/teamroots/embers/tileentity/TileEntityFluidExtractor.java
+++ b/src/main/java/teamroots/embers/tileentity/TileEntityFluidExtractor.java
@@ -283,7 +283,7 @@ public class TileEntityFluidExtractor extends TileEntityFluidPipeBase {
         if (world.isRemote && clogged)
             Misc.spawnClogParticles(world, pos, 1, 0.25f);
         if (!world.isRemote) {
-            active = getWorld().isBlockIndirectlyGettingPowered(getPos()) != 0;
+            active = getWorld().isBlockPowered(getPos());
             for (EnumFacing facing : EnumFacing.VALUES) {
                 if (!isConnected(facing))
                     continue;

--- a/src/main/java/teamroots/embers/tileentity/TileEntityItemExtractor.java
+++ b/src/main/java/teamroots/embers/tileentity/TileEntityItemExtractor.java
@@ -344,7 +344,7 @@ public class TileEntityItemExtractor extends TileEntityItemPipeBase implements I
             Misc.spawnClogParticles(world, pos, 1, 0.25f);
         if (!world.isRemote) {
             cleanupOrders();
-            active = getWorld().isBlockIndirectlyGettingPowered(getPos()) != 0;
+            active = getWorld().isBlockPowered(getPos());
             OrderStack currentOrder = orders.isEmpty() ? null : orders.get(0);
             IFilter filter = FilterUtil.FILTER_ANY;
             if(active)

--- a/src/main/java/teamroots/embers/tileentity/TileEntityItemRequisition.java
+++ b/src/main/java/teamroots/embers/tileentity/TileEntityItemRequisition.java
@@ -230,7 +230,7 @@ public class TileEntityItemRequisition extends TileEntity implements ITileEntity
         if (!world.isRemote) {
             boolean isPowered = false;
             //if (!isIntelligent()) {
-                isPowered = getWorld().isBlockIndirectlyGettingPowered(getPos()) != 0;
+                isPowered = getWorld().isBlockPowered(getPos());
                 int filterSize = getFilterSize();
                 TileEntity attached = getAttached();
                 int count = 0;

--- a/src/main/java/teamroots/embers/tileentity/TileEntityPulser.java
+++ b/src/main/java/teamroots/embers/tileentity/TileEntityPulser.java
@@ -167,7 +167,7 @@ public class TileEntityPulser extends TileEntity implements ITileEntityBase, ITi
 				}
 			}
 		}
-		if ((this.ticksExisted+offset) % 20 == 0 && getWorld().isBlockIndirectlyGettingPowered(getPos()) != 0 && target != null && !getWorld().isRemote && this.capability.getEmber() > PULL_RATE){
+		if ((this.ticksExisted+offset) % 20 == 0 && getWorld().isBlockPowered(getPos()) && target != null && !getWorld().isRemote && this.capability.getEmber() > PULL_RATE){
 			TileEntity targetTile = getWorld().getTileEntity(target);
 			if (targetTile instanceof IEmberPacketReceiver){
 				if (!(((IEmberPacketReceiver) targetTile).isFull())){


### PR DESCRIPTION
So, hear me out on this one.  
First of all, let's get the quick stuff out of the way.  
1. Checking `World.isBlockPowered(pos)` is the same as `World.isBlockIndirectlyGettingPowered(pos) != 0`, and that can be demonstrated just by looking at the code of those functions. As I said in one of the commit messages, the latter should've just been called `World.getRedstonePower(pos)`. And the comment above that function is also wrong - neither TNT nor Doors use this function - they all check `isBlockPowered`.
2. Copying the function into `TileEntityBreaker` was completely unnecessary.
3. Half of the blocks that `canConnectRedstone()` don't actually do anything with it.
4. Just returning `true` from `canConnectRedstone` is reserved to redstone dust that can connect to other dust blocks diagonally. Other blocks that aren't supposed to do that should `return side != null;`.

Now, to the main part. Why did I remove the `canConnectRedstone` from all these blocks?
There is a bug in BlockRedstoneWire.

In vanilla 1.12 there isn't a single block - aside from redstone dust itself, repeaters and comparators - that would redirect redstone dust into themselves, NOT provide power to it, AND change their own state based on incoming redstone power. And those three detect the power coming into them by explicitly checking if a block next to them is actually a redstone wire, and if it is - they just take the power level from it's blockstate.

The bug itself, that requires a check described above to actually exist, comes from the `getWeakPower` function in `BlockRedstoneWire` class.
```java
    public int getWeakPower(IBlockState blockState, IBlockAccess blockAccess, BlockPos pos, EnumFacing side) {
        // IMPORTANT: side actually describes the direction, from which this dust is being queried. e.g. if the querying block is on the west side of the dust - `side = EnumFacing.EAST`.
        if (!this.canProvidePower) // if the dust doesn't provide power
            return 0;  // obviously.
        int i = ((Integer)blockState.getValue(POWER)).intValue();  // get signal level on this dust
        if (i == 0)  // if it is missing
            return 0;  // obviously.
        if (side == EnumFacing.UP) // if the dust is directly on top of the block that queries it
            return i;  // return the signal.

        EnumSet<EnumFacing> enumset = EnumSet.<EnumFacing>noneOf(EnumFacing.class);  // empty set of sides
        for (EnumFacing enumfacing : EnumFacing.Plane.HORIZONTAL)  // looping over all horisontal facings
            if (this.isPowerSourceAt(blockAccess, pos, enumfacing))  // if the dust is connected to that side
                enumset.add(enumfacing);  // we put it into the set.

        if (side.getAxis().isHorizontal() && enumset.isEmpty())  // if the dust isn't connected to anything (is a dot) and the block is sideways from it
            return i;  // then it powers the block.
        if (enumset.contains(side) && !enumset.contains(side.rotateYCCW()) && !enumset.contains(side.rotateY()))
        {  // if the dust is connected to the side OPPOSITE of the querying block and not turned away from it
            return i; // then the block is powered.
        } return 0;  // else - it isn't.
    }
```
Which check is missing? The check for if the dust is connected to the querying block is missing.
`if (enumset.contains(side.getOpposite())) return i;`
Which basically means that if the dust is in L-shape or T-shape, with one side connecting to the querying block, it won't actually tell the block that it is powered.
Thus we get a visual conflict: the dust clearly connects to the block but isn't powering it!
This is why I turned off redstone dust connecting to blocks that actually do react to it. Because turning it on and getting expected results would need a patch into Forge, which is basically not happening, or to partially reimplement `isBlockPowered` for all the blocks that do need that check.
Having the dust not being redirected by Embers machines at least does not confuse players. They act more in-line with things like pistons and redstone lamps.