### PR TITLE
Register the FLOAT_ARRAY correctly

### DIFF
--- a/src/main/java/teamroots/embers/RegistryManager.java
+++ b/src/main/java/teamroots/embers/RegistryManager.java
@@ -37,6 +37,7 @@ import net.minecraftforge.fml.common.registry.EntityRegistry;
 import net.minecraftforge.fml.common.registry.GameRegistry;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
+import net.minecraftforge.registries.DataSerializerEntry;
 import teamroots.embers.api.EmbersAPI;
 import teamroots.embers.api.power.IEmberCapability;
 import teamroots.embers.api.upgrades.IUpgradeProvider;
@@ -851,5 +852,10 @@ public class RegistryManager {
 				((IModeledItem)items.get(i)).initModel();
 			}
 		}
+	}
+
+	@SubscribeEvent
+	public void init(RegistryEvent.Register<DataSerializerEntry> event) {
+		event.getRegistry().register(new DataSerializerEntry(ExtraSerializers.FLOAT_ARRAY).setRegistryName(Embers.MODID, "serializer_float_array"));
 	}
 }

--- a/src/main/java/teamroots/embers/util/ExtraSerializers.java
+++ b/src/main/java/teamroots/embers/util/ExtraSerializers.java
@@ -34,8 +34,4 @@ public class ExtraSerializers {
             return value.clone();
         }
     };
-
-    static {
-        DataSerializers.registerSerializer(FLOAT_ARRAY);
-    }
 }


### PR DESCRIPTION
What title says.
If a Magma Worm gets spawned on a server - all players who try to receive data about it get into a kick loop.
Fix: register the custom DataSerializer correctly.