### PR TITLE
Only set entities on fire if damage was successful

### DIFF
--- a/src/main/java/teamroots/embers/api/projectile/EffectDamage.java
+++ b/src/main/java/teamroots/embers/api/projectile/EffectDamage.java
@@ -57,8 +57,8 @@ public class EffectDamage implements IProjectileEffect {
     public void onEntityImpact(Entity entity, @Nullable IProjectilePreset projectile) {
         Entity shooter = projectile != null ? projectile.getShooter() : null;
         Entity projectileEntity = projectile != null ? projectile.getEntity() : null;
-        entity.attackEntityFrom(source.apply(projectile),damage);
-        entity.setFire(fire);
+        if (entity.attackEntityFrom(source.apply(projectile),damage))
+            entity.setFire(fire);
         if(entity instanceof EntityLivingBase) {
             EntityLivingBase livingTarget = (EntityLivingBase) entity;
             livingTarget.setLastAttackedEntity(shooter);


### PR DESCRIPTION
Again, what title says.
The problem is basically this: anti-grief plugins can detect and cancel incoming damage, but they have no control over setting entities on fire.
This PR ensures that entities are only ever set on fire if damage wasn't canceled in one way or another.
This fixes issues where Embers' weapons could be used to kill animals in other player claims/regions just with fire damage.