### PR TITLE
Fix alchemy tablet breaking after 10 days of existing

### DIFF
--- a/src/main/java/teamroots/embers/tileentity/TileEntityAlchemyTablet.java
+++ b/src/main/java/teamroots/embers/tileentity/TileEntityAlchemyTablet.java
@@ -295,7 +295,7 @@ public class TileEntityAlchemyTablet extends TileEntity implements ITileEntityBa
 
     @Override
     public void update() {
-        angle += 1.0f;
+        angle += 1;
         List<IUpgradeProvider> upgrades = UpgradeUtil.getUpgrades(world, pos, new EnumFacing[]{EnumFacing.DOWN}); //Defer to when events are added to the upgrade system
         UpgradeUtil.verifyUpgrades(this, upgrades);
         if (getWorld().isRemote)


### PR DESCRIPTION
The alchemy tablet seizes to function after existing for 16777216 ticks. This happens because the angle field gets incremented by a float value instead of an int value. The number of ticks is the maximum number a 24 bit value can represent and after this it does not increment anymore. If this happens the value will forever be stuck at 16777216 and the condition `angle % 10 == 0` will never be true, thus preventing any recipe from ever finishing. We noticed this because we used tile entity acceleration and it broke after roughly 4.5 hours every time.

This behavior can be seen in this video:

https://user-images.githubusercontent.com/45769595/136627917-56fc826b-a381-4c5b-aed2-592b16e18c21.mp4