### PR TITLE
Fix Item Requisition occasionally deleting items

### DIFF
--- a/src/main/java/teamroots/embers/tileentity/TileEntityItemRequisition.java
+++ b/src/main/java/teamroots/embers/tileentity/TileEntityItemRequisition.java
@@ -98,6 +98,8 @@ public class TileEntityItemRequisition extends TileEntity implements ITileEntity
             }
 
             ItemStack merge(ItemStack first, ItemStack second) {
+                if(first.isEmpty())
+                    return second;
                 if (!ItemHandlerHelper.canItemStacksStack(first, second))
                     return first;
                 first = first.copy();


### PR DESCRIPTION
`canItemStacksStack()` will return false if the first stack is empty. This means if you try to insert an unstackable item into a non-smart requisition connected to a full container, it'll:  
1. Shrink that first stack to being empty.  
2. Fail to insert the split stack into the container.  
3. Try to merge the first stack and the split stack.
4. Get `false` from `canItemStacksStack()` because the first stack is empty  
5. Return the empty stack because of the `return first`, deleting the item you're trying to insert