### PR TITLE
Fix Golem Eye

### DIFF
--- a/src/main/java/teamroots/embers/api/item/IFilterItem.java
+++ b/src/main/java/teamroots/embers/api/item/IFilterItem.java
@@ -1,8 +1,14 @@
 package teamroots.embers.api.item;
 
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
 import teamroots.embers.api.filter.IFilter;
 
 public interface IFilterItem {
     IFilter getFilter(ItemStack stack);
+
+	default void setFilter(ItemStack stack, IFilter filter) {
+        NBTTagCompound compound = stack.getOrCreateSubCompound("filter");
+        filter.writeToNBT(compound);
+	}
 }


### PR DESCRIPTION
Currently, the filter isn't correctly written to the NBT, removing almost all use to the golem eye.  
Also, if you hold the eye in your offhand and use it it'll write the NBT to the item in your main hand (if you are holding one).

This pull request fixes both of those bugs in a way that shouldn't cause any issues with addons.